### PR TITLE
When running silently without GUI, wait for the application to exit

### DIFF
--- a/executor/shellCommands.go
+++ b/executor/shellCommands.go
@@ -54,22 +54,20 @@ func executeApp(app App) error {
 		}
 	}
 
+	var err error
+
 	if (exitAfterExec) {
-		err := cmd.Run()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
+		err = cmd.Run()
 	} else {
-		err := cmd.Start()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
+		err = cmd.Start()
+	}
+
+	if err != nil {
+		fmt.Println(err)
+		return err
 	}
 
 	return nil
-
 }
 
 func seperatePathFromExecutable(path string) (string, string, string) {

--- a/executor/shellCommands.go
+++ b/executor/shellCommands.go
@@ -54,11 +54,20 @@ func executeApp(app App) error {
 		}
 	}
 
-	err := cmd.Start()
-	if err != nil {
-		fmt.Println(err)
-		return err
+	if (exitAfterExec) {
+		err := cmd.Run()
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+	} else {
+		err := cmd.Start()
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
 	}
+
 	return nil
 
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 //VERSION const
-const VERSION = "0.4.1"
+const VERSION = "0.4.2"
 
 //noGui bool
 var noGui bool = false


### PR DESCRIPTION
This fixes the issue where, if you run a donor game using RPD with -runsilent, Steam will consider the game immediately closed (since it's looking at the RPD process) and in that case, Remote Play Together is not available